### PR TITLE
fix compilation for bionic libc (android/termux)

### DIFF
--- a/daemon/io.h
+++ b/daemon/io.h
@@ -27,6 +27,9 @@
 
 #ifdef __APPLE__
 #include <net/ethernet.h>
+#elif __BIONIC__
+#include <net/ethernet.h>
+#include <netinet/ether.h>
 #else
 #include <netinet/ether.h>
 #endif

--- a/daemon/netutils.h
+++ b/daemon/netutils.h
@@ -24,6 +24,9 @@
 #include <netinet/in.h>
 #ifdef __APPLE__
 #include <net/ethernet.h>
+#elif __BIONIC__
+#include <net/ethernet.h>
+#include <netinet/ether.h>
 #else
 #include <netinet/ether.h>
 #endif

--- a/src/ieee80211.h
+++ b/src/ieee80211.h
@@ -6,6 +6,9 @@
 #ifdef __APPLE__
 
 #include <net/ethernet.h>
+#elif __BIONIC__
+#include <net/ethernet.h>
+#include <netinet/ether.h>
 
 #else
 #include <netinet/ether.h>


### PR DESCRIPTION
includes the right libraries for bionic libc based OS (android)

should fix https://github.com/seemoo-lab/owl/issues/66 ("struct ether_addr" error part at least)